### PR TITLE
Add resisting_deployment_error metric

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,9 +1,9 @@
 go: 1.6.2
 repository:
-    path: github.com/stuartnelson3/passenger_exporter_nginx
+    path: github.com/stuartnelson3/passenger_exporter
 build:
     binaries:
-        - name: passenger_exporter_nginx
+        - name: passenger_exporter
     flags: -a -tags -installsuffix
     ldflags: |
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM busybox
 MAINTAINER stn@soundcloud.com
 
-ADD passenger_exporter_nginx /
+ADD passenger_exporter /

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION   := $(shell cat VERSION)
-BIN       := passenger_exporter_nginx
-CONTAINER := passenger_exporter_nginx
+BIN       := passenger_exporter
+CONTAINER := passenger_exporter
 GOOS      ?= linux
 GOARCH    ?= amd64
 
@@ -10,10 +10,14 @@ DST       ?= http://ent.int.s-cloud.net/iss/$(BIN)
 
 PREFIX    ?= $(shell pwd)
 
+GO           := GO15VENDOREXPERIMENT=1 go
+FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
+PROMU        := $(FIRST_GOPATH)/bin/promu
+
 default: $(BIN)
 
 $(BIN):
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) promu build --prefix $(PREFIX)
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(PROMU) build --prefix $(PREFIX)
 
 release: $(TAR)
 	curl -XPOST --data-binary @$< $(DST)/$<

--- a/README
+++ b/README
@@ -1,6 +1,6 @@
-************************
-passenger_exporter_nginx
-------------------------
+******************
+passenger_exporter
+------------------
 
 This is a Prometheus exporter for passenger with nginx integration.
 
@@ -20,7 +20,7 @@ make build-docker
 Running the Exporter
 --------------------
 
-Usage of passenger_exporter_nginx:
+Usage of passenger_exporter:
   -log.format value
       If set use a syslog logger or JSON logging.
       Example: logger:syslog?appname=bob&local=7 or logger:stdout?json=true.
@@ -43,7 +43,7 @@ Usage of passenger_exporter_nginx:
 To run the Docker image:
 
 docker run -p 9106:9106 -v $PATH_TO_PASSENGER_STATUS:/bin \
-        passenger_exporter_nginx:latest /passenger_exporter_nginx
+        passenger_exporter:latest /passenger_exporter
 
 Notes for running the Docker container:
 

--- a/main.go
+++ b/main.go
@@ -160,7 +160,10 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(e.toplevelQueue, prometheus.GaugeValue, parseFloat(info.TopLevelRequestsInQueue))
 	ch <- prometheus.MustNewConstMetric(e.maxProcessCount, prometheus.GaugeValue, parseFloat(info.MaxProcessCount))
 	ch <- prometheus.MustNewConstMetric(e.currentProcessCount, prometheus.GaugeValue, parseFloat(info.CurrentProcessCount))
-	ch <- prometheus.MustNewConstMetric(e.appCount, prometheus.GaugeValue, parseFloat(info.AppCount))
+
+	if info.AppCount != "" {
+		ch <- prometheus.MustNewConstMetric(e.appCount, prometheus.GaugeValue, parseFloat(info.AppCount))
+	}
 
 	for _, sg := range info.SuperGroups {
 		resistingDeploymentError := 0.0

--- a/main.go
+++ b/main.go
@@ -345,7 +345,7 @@ func main() {
 
 	http.Handle(*metricsPath, prometheus.Handler())
 
-	log.Infoln("starting passenger_exporter_nginx", version.Info())
+	log.Infoln("starting passenger_exporter", version.Info())
 	log.Infoln("build context", version.BuildContext())
 	log.Infoln("listening on", *listenAddress)
 	log.Fatal(http.ListenAndServe(*listenAddress, nil))

--- a/structs.go
+++ b/structs.go
@@ -37,6 +37,7 @@ type Group struct {
 	DisableWaitListSize   string    `xml:"disable_wait_list_size"`
 	GID                   string    `xml:"gid"`
 	ProcessesSpawning     string    `xml:"processes_being_spawned"`
+	ResistingDeploymentError *struct{} `xml:"resisting_deployment_error"`
 	Options               Options   `xml:"options"`
 	Processes             []Process `xml:"processes>process"`
 }

--- a/testdata/passenger_xml_output.xml
+++ b/testdata/passenger_xml_output.xml
@@ -31,6 +31,7 @@
         <uid>5001</uid>
         <group>daemon</group>
         <gid>1</gid>
+        <resisting_deployment_error/>
         <options>
           <app_root>/src/app/my_app</app_root>
           <app_group_name>/srv/app/my_app &#40;production&#41;</app_group_name>


### PR DESCRIPTION
Metric is useful to track `passenger-server-enterprise`'s Resisting Deployment Error state.

This state allow to see if there is deployment error - when Passenger can't spawn new workers due to an application loading issue.